### PR TITLE
add MultiViewTyper interface for random data get viewType

### DIFF
--- a/app/src/main/java/com/github/markzhai/recyclerview/demo/MainActivity.java
+++ b/app/src/main/java/com/github/markzhai/recyclerview/demo/MainActivity.java
@@ -29,6 +29,8 @@ import com.github.markzhai.recyclerview.SingleTypeAdapter;
 import com.github.markzhai.recyclerview.demo.databinding.ActivityMainBinding;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -84,6 +86,7 @@ public class MainActivity extends AppCompatActivity {
             Toast.makeText(MainActivity.this, "employee " + model.name, Toast.LENGTH_SHORT).show();
 
         }
+
         public void onItemClick(EmployerViewModel model) {
             Toast.makeText(MainActivity.this, "employer " + model.name, Toast.LENGTH_SHORT).show();
         }
@@ -132,5 +135,24 @@ public class MainActivity extends AppCompatActivity {
         mMultiTypeAdapter.add(null, VIEW_TYPE_HEADER);
         mMultiTypeAdapter.addAll(EMPLOYEE_LIST, VIEW_TYPE_EMPLOYEE);
         mMultiTypeAdapter.addAll(EMPLOYER_LIST, VIEW_TYPE_EMPLOYER);
+
+        final List<Object> data = new ArrayList<Object>();
+        data.addAll(EMPLOYEE_LIST);
+        data.addAll(EMPLOYER_LIST);
+        Collections.shuffle(data);
+        mMultiTypeAdapter.addAll(data, new MultiTypeAdapter.MultiViewTyper() {
+            @Override
+            public int getViewType(Object item) {
+                if (item instanceof EmployerViewModel) {
+                    return VIEW_TYPE_EMPLOYER;
+                }
+
+                if (item instanceof EmployeeViewModel) {
+                    return VIEW_TYPE_EMPLOYEE;
+                }
+
+                return 0;
+            }
+        });
     }
 }

--- a/recyclerviewadapter/src/main/java/com/github/markzhai/recyclerview/MultiTypeAdapter.java
+++ b/recyclerviewadapter/src/main/java/com/github/markzhai/recyclerview/MultiTypeAdapter.java
@@ -17,6 +17,10 @@ import java.util.Map;
  */
 public class MultiTypeAdapter extends BaseViewAdapter<Object> {
 
+    public interface MultiViewTyper {
+        int getViewType(Object item);
+    }
+
     protected ArrayList<Integer> mCollectionViewType;
 
     private ArrayMap<Integer, Integer> mItemTypeToLayoutMap = new ArrayMap<>();
@@ -57,6 +61,13 @@ public class MultiTypeAdapter extends BaseViewAdapter<Object> {
         addAll(viewModels, viewType);
     }
 
+    public void set(List viewModels, MultiViewTyper viewTyper) {
+        mCollection.clear();
+        mCollectionViewType.clear();
+
+        addAll(viewModels, viewTyper);
+    }
+
     public void add(Object viewModel, int viewType) {
         mCollection.add(viewModel);
         mCollectionViewType.add(viewType);
@@ -73,6 +84,14 @@ public class MultiTypeAdapter extends BaseViewAdapter<Object> {
         mCollection.addAll(viewModels);
         for (int i = 0; i < viewModels.size(); ++i) {
             mCollectionViewType.add(viewType);
+        }
+        notifyDataSetChanged();
+    }
+
+    public void addAll(List viewModels, MultiViewTyper multiViewTyper) {
+        mCollection.addAll(viewModels);
+        for (int i = 0; i < viewModels.size(); ++i) {
+            mCollectionViewType.add(multiViewTyper.getViewType(viewModels.get(i)));
         }
         notifyDataSetChanged();
     }


### PR DESCRIPTION
添加 MultiViewTyper接口，方便从不确定顺序的数据中获取viewType。

``` java
    final List<Object> data = new ArrayList<Object>();
        data.addAll(EMPLOYEE_LIST);
        data.addAll(EMPLOYER_LIST);
        Collections.shuffle(data);
        mMultiTypeAdapter.addAll(data, new MultiTypeAdapter.MultiViewTyper() {
            @Override
            public int getViewType(Object item) {
                if (item instanceof EmployerViewModel) {
                    return VIEW_TYPE_EMPLOYER;
                }

                if (item instanceof EmployeeViewModel) {
                    return VIEW_TYPE_EMPLOYEE;
                }

                return 0;
            }
        });
```
